### PR TITLE
Fix Extended logging

### DIFF
--- a/src/Oriflame.RedisMessaging.ReliableDelivery/Subscribe/ReliableSubscriber.cs
+++ b/src/Oriflame.RedisMessaging.ReliableDelivery/Subscribe/ReliableSubscriber.cs
@@ -91,7 +91,7 @@ namespace Oriflame.RedisMessaging.ReliableDelivery.Subscribe
             }
 
             var messageProcessor = CreateMessageProcessor(channel, handler);
-            queue.OnMessage(channelMessage => HandleMessage(channel, channelMessage.Message, messageProcessor));
+            queue.OnMessage(channelMessage => HandleMessage(channelMessage.Channel, channelMessage.Message, messageProcessor));
 
             return messageProcessor;
         }


### PR DESCRIPTION
messages contain a channel name from which a message arrived. Previously only channel name known at time of subscribing was logged.