### PR TITLE
Logging of duplicated or delayed messages changed slightly

### DIFF
--- a/src/Oriflame.RedisMessaging.ReliableDelivery/Subscribe/MessageProcessor.cs
+++ b/src/Oriflame.RedisMessaging.ReliableDelivery/Subscribe/MessageProcessor.cs
@@ -9,7 +9,7 @@ namespace Oriflame.RedisMessaging.ReliableDelivery.Subscribe
     /// <inheritdoc cref="IMessageDeliveryChecker" />
     internal class MessageProcessor : IMessageProcessor, IMessageDeliveryChecker
     {
-        private readonly TimeSpan _pubSubReceivedHandledThreshold = TimeSpan.FromSeconds(2);
+        private readonly TimeSpan _pubSubReceivedHandledThreshold;
         private readonly IMessageValidator _messageValidator;
         private readonly IMessageLoader _messageLoader;
         private readonly IMessageHandler _messageHandler;

--- a/test/Oriflame.RedisMessaging.ReliableDelivery.Tests/Subscribe/MessageProcessorTest.cs
+++ b/test/Oriflame.RedisMessaging.ReliableDelivery.Tests/Subscribe/MessageProcessorTest.cs
@@ -28,8 +28,10 @@ namespace Oriflame.RedisMessaging.ReliableDelivery.Tests.Subscribe
 
             public IEnumerable<Message> NewestMessages { get; set; }
 
-            protected override void HandleMessageImpl(Message message, string physicalOrLogicalChannel)
+            protected override void HandleMessageImpl(Message message, string physicalOrLogicalChannel, bool isBulkProcessing, out IMessageValidationResult validationResult)
             {
+                validationResult = null;
+
                 if (_isRunning)
                 {
                     var error = $"Is running for message {message}";


### PR DESCRIPTION
- if a message is handled by polling (backup link) earlier than it comes from the PubSub channel then it is logged under Debug log level (it was a warning till now) => the message comes successfully
- monitor the difference between message receiving and handling times. Log warning message when the delay is higher than 2s => it seems like an issue in the PubSub channel
- ignore duplicated messages got by polling => they have been received already from the PubSub channel